### PR TITLE
feat: ユーザーが新しい英単語と日本語訳を登録できるようにする

### DIFF
--- a/wordbook.py
+++ b/wordbook.py
@@ -1,15 +1,18 @@
+import re
+
+
 def main():
     """単語帳アプリケーションのメイン関数"""
     word_dict = {}
 
     while True:
-        print("実行したい操作の番号を入力してください")
+        print("=== 実行したい操作の番号を入力してください ===")
         print("1: 単語登録")
         print("2: クイズ")
         print("3: 終了")
 
         try:
-            choice_mode = int(input(">>>"))
+            choice_mode = int(input(">>> "))
 
         except ValueError:
             print("エラー: 半角数字で入力してください")
@@ -27,11 +30,81 @@ def main():
 
 
 def register_word(word):
-    print("単語登録を行います")
+    print("=== 単語登録を行います ===")
+
+    while True:
+        print("英単語を入力してください")
+        input_eg_word = input(">>> ")
+
+        if is_half_width_alpha_only(input_eg_word):
+            break
+        else:
+            print("エラー: 英単語は半角英字で入力してください")
+
+    while True:
+        print("入力した英単語の日本語訳を入力してください")
+        translation_jp_word = input(">>> ")
+        if is_japanese_char_only(translation_jp_word):
+            break
+        else:
+            print("エラー: 日本語訳は 漢字・ひらがな・カタカナで入力してください")
+
+    word[input_eg_word] = translation_jp_word
+
+    print("以下の英単語と日本語訳を保存しました")
+    print(f"英単語: {input_eg_word}")
+    print(f"日本語訳: {translation_jp_word}")
 
 
 def start_quiz(word):
     print("クイズを行います")
+
+
+def is_half_width_alpha_only(text):
+    """
+    文字列が半角アルファベット（a-z, A-Z）のみで構成されているかを判定します。
+    """
+
+    # 文字列が空の場合はFalseとする
+    if not text:
+        return False
+
+    # 正規表現パターン
+    # ^: 文字列の先頭
+    # $: 文字列の末尾
+    # [a-zA-Z]+: aからz、AからZのいずれかの文字が1回以上続く
+    alpha_pattern = r"^[a-zA-Z]+$"
+
+    if re.fullmatch(alpha_pattern, text):
+        return True
+    else:
+        return False
+
+
+def is_japanese_char_only(text):
+    """
+    文字列が漢字、ひらがな、カタカナ（全角）のみで構成されているかを判定します。
+    長音符「ー」や、繰り返し記号「々」も含みます。
+    """
+
+    # 文字列が空の場合はFalseとする
+    if not text:
+        return False
+
+    # 正規表現パターン
+    # ^: 文字列の先頭
+    # $: 文字列の末尾
+    # [...]+: [...]内のいずれかの文字が1回以上続く
+    # \u4E00-\u9FFF: CJK統合漢字（一般的な漢字）
+    # \u3040-\u309F: ひらがな
+    # \u30A0-\u30FF: カタカナ（全角）
+    # ー: 長音符
+    # 々: 繰り返し記号
+    japanese_pattern = r"^[一-龠ぁ-んァ-ヶー々]+$"
+    if re.fullmatch(japanese_pattern, text):
+        return True
+    else:
+        return False
 
 
 # --- プログラムの実行開始点　---


### PR DESCRIPTION
Close #2

## Why
ユーザーにクイズで使用する英単語と日本語訳のペアを入力してもらい、メモリ上に保存する。

## What (機能要件)
- ユーザーは、英単語（半角英字のみ）を入力できる。
- ユーザーは、日本語訳（漢字・ひらがな・カタカナのみ）を入力できる。
- 入力されたペアは、プログラム内の辞書に保存される。
- 登録完了後、登録内容がユーザーにフィードバックされる。

## チェックリスト (実装内容)
- [x] 英単語入力のプロンプトとロジックを実装。
- [x] 日本語訳入力のプロンプトとロジックを実装。
- [x] 半角英字を判定する正規表現関数 `is_half_width_alpha_only` を作成。
- [x] 日本語文字を判定する正規表現関数 `is_japanese_char_only` を作成。
- [x] `while`ループを用いた入力値バリデーションを実装。
- [x] バリデーションを通過した値を辞書オブジェクトに追加。
- [x] 登録完了メッセージの表示機能を実装。