### PR TITLE
feat:登録された単語からクイズを出題し、正誤を判定する機能を実装

### DIFF
--- a/wordbook.py
+++ b/wordbook.py
@@ -61,6 +61,7 @@ def start_quiz(word):
     print("=== クイズを行います ===")
     if word == {}:
         print("登録された英単語がありません。英単語を登録してください")
+        return
 
     else:
         # word_dictのキーをリストで保持し、ランダムに１つ抽出

--- a/wordbook.py
+++ b/wordbook.py
@@ -1,4 +1,5 @@
 import re
+import random
 
 
 def main():
@@ -62,8 +63,11 @@ def start_quiz(word):
         print("登録された英単語がありません。英単語を登録してください")
 
     else:
-        print("==== デバック ====")
-        print(word)
+        # word_dictのキーをリストで保持し、ランダムに１つ抽出
+        all_keys = list(word.keys())
+        choice_key = random.choice(all_keys)
+        # キーに対応する日本語訳をプロンプトに表示
+        print(f"'{word[choice_key]}'を英訳して入力してください")
 
 
 def is_half_width_alpha_only(text):

--- a/wordbook.py
+++ b/wordbook.py
@@ -57,7 +57,13 @@ def register_word(word):
 
 
 def start_quiz(word):
-    print("クイズを行います")
+    print("=== クイズを行います ===")
+    if word == {}:
+        print("登録された英単語がありません。英単語を登録してください")
+
+    else:
+        print("==== デバック ====")
+        print(word)
 
 
 def is_half_width_alpha_only(text):

--- a/wordbook.py
+++ b/wordbook.py
@@ -78,6 +78,13 @@ def start_quiz(word):
         else:
             print("エラー: 英訳は半角英字のみで入力してください")
 
+    # ユーザーの回答とword_dictのキーを比較し、正誤判定を行う
+    if answer_eg_word == choice_key:
+        print("正解です！")
+    else:
+        print("不正解です")
+        print(f"正解は{choice_key}です")
+
 
 def is_half_width_alpha_only(text):
     """

--- a/wordbook.py
+++ b/wordbook.py
@@ -69,6 +69,9 @@ def start_quiz(word):
         choice_key = random.choice(all_keys)
         # キーに対応する日本語訳をプロンプトに表示
         print(f"'{word[choice_key]}'を英訳して入力してください")
+        answer_eg_word = input("<<< ")
+        print("#### デバック ####")
+        print(answer_eg_word)
 
 
 def is_half_width_alpha_only(text):

--- a/wordbook.py
+++ b/wordbook.py
@@ -67,11 +67,16 @@ def start_quiz(word):
         # word_dictのキーをリストで保持し、ランダムに１つ抽出
         all_keys = list(word.keys())
         choice_key = random.choice(all_keys)
-        # キーに対応する日本語訳をプロンプトに表示
+
+    # キーに対応する日本語訳をプロンプトに表示し、ユーザーに英単語の入力を求める
+    # 入力は半角英字のみを許可する
+    while True:
         print(f"'{word[choice_key]}'を英訳して入力してください")
         answer_eg_word = input("<<< ")
-        print("#### デバック ####")
-        print(answer_eg_word)
+        if is_half_width_alpha_only(answer_eg_word):
+            break
+        else:
+            print("エラー: 英訳は半角英字のみで入力してください")
 
 
 def is_half_width_alpha_only(text):


### PR DESCRIPTION
# colse3

## Why
- 登録された辞書の日本語訳をランダムに１つ表示し、ユーザーの入力値と一致するかを判定することで実装する

## What
- 登録されている単語がない場合は、「先に単語を登録してください」というメッセージを表示する。
- `random`モジュールを使い、登録済みの単語からランダムに1つを選ぶ。
- 選ばれた単語の日本語訳をユーザーに表示する。
- ユーザーに英単語の入力を促す。
- ユーザーの回答と正解を比較し、正誤判定の結果を表示する。

## チェックリスト
- [x] `word_dict`が空でないか確認する条件分岐を実装
- [x] `random.choice`を用いて表示する`word_dict`のキー(英単語)を取得
- [x] 上記のキーを用いて日本語訳を表示する
- [x] 回答を促すプロンプトを実装
- [x] 回答は`while`ループと`is_half_width_alpha_only()`関数を用いて、半角英字に制限する
- [x] 回答が `word_dict`のキーと一致するか判定する条件分岐を実装