### PR TITLE
fix: 不足していたmain()関数のバリーデーションエラーのwarningログを追加

### DIFF
--- a/wordbook/main.py
+++ b/wordbook/main.py
@@ -27,6 +27,7 @@ def run_app():
             choice_mode = int(input(">>> "))
 
         except ValueError:
+            logger.warning("無効な入力です: 整数以外が入力されました。")
             print("エラー: 半角数字で入力してください")
             continue
 
@@ -39,4 +40,5 @@ def run_app():
             logger.info("アプリケーションを終了")
             break
         else:
+            logger.warning("無効な入力です: 選択肢以外の整数が入力されました。")
             print("有効な数字を入力してください")


### PR DESCRIPTION
#15 の対応で漏れていた以下を実装
mian()関数内のバリデーションエラー時のwarningログ
- [x] メニュー選択時のValueError時
- [x] メニュー選択時の選択肢外の整数入力時 
